### PR TITLE
Add set_paper_trail_controller_info

### DIFF
--- a/lib/grape/papertrail.rb
+++ b/lib/grape/papertrail.rb
@@ -4,9 +4,13 @@ module Grape
     def self.included(base)
       Grape::Endpoint.class_eval do
 
-        def set_papertrail_user user
-	  ::PaperTrail.whodunnit = user
+        def set_papertrail_user(user)
+          ::PaperTrail.whodunnit = user
         end
+        
+        def set_paper_trail_controller_info(info)
+          ::PaperTrail.controller_info = info
+      	end
 
       end
     end


### PR DESCRIPTION
Hey, thanks for the gem!

I've added the method "set_paper_trail_controller_info" alongside your other method, so one can add the arbitrary "controller" meta info through grape, since it doesn't use ActionController :)
